### PR TITLE
Commodore Plus4: Replaced absolute paths in sym-lib-table with relative paths

### DIFF
--- a/Commodore/Plus4/sym-lib-table
+++ b/Commodore/Plus4/sym-lib-table
@@ -1,3 +1,3 @@
 (sym_lib_table
-  (lib (name Commodore)(type Legacy)(uri /home/greg/nfs/KiCad/CommodorePlus4/Commodore.lib)(options "")(descr ""))
+  (lib (name Commodore)(type Legacy)(uri ${KIPRJMOD}/Commodore.lib)(options "")(descr ""))
 )


### PR DESCRIPTION
Replaced sym-lib-table absolute paths from initial submitter's file system with project relative paths, so that libs can be found when schematic is opened on other people's working copies.