### PR TITLE
add Apple_II_Rev0 (as a submodule, because it contains larger files than GitHub allows :-P )

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "Tandy-RS/Model 100"]
 	path = Tandy-RS/Model 100
 	url = https://github.com/hzeller/trs80-100-schematic
+[submodule "Apple/Apple II/Apple_II_Rev0"]
+	path = Apple/Apple II/Apple_II_Rev0
+	url = https://git.alfter.us/salfter/Apple_II_Rev0


### PR DESCRIPTION
I started with a known-working PCB layout posted by Mike Willegal and used the Red Book to construct KiCad schematics and a PCB for the rev. 0 Apple II.

(I tried merging my repo at https://git.alfter.us/salfter/Apple_II_Rev0 into this repo, but it contains a ~230MB STEP model that GitHub doesn't like.  I could just import the current state of my repo, but that'd lose the history.  This commit adds my repo as a submodule, so the history and all documentation are available.)